### PR TITLE
Report presence change correctly

### DIFF
--- a/test/integration/SessionManagementClient.spec.ts
+++ b/test/integration/SessionManagementClient.spec.ts
@@ -69,7 +69,7 @@ describe('Integration - Session Management Client', () => {
         // Wait for sync
         await sleep('1s')
 
-        // Logout both users, and wait for logut
+        // Logout both users, and wait for logout
         await client.logout()
         await oldFriend.logout()
         await sleep('1s')


### PR DESCRIPTION
By listening to the event `event` (instead of `User.lastPresenceTs`) we can correctly listen to presence changes