### PR TITLE
fix: fix pipeline

### DIFF
--- a/test/integration/containers/synapse/SynapseContainerBuilder.ts
+++ b/test/integration/containers/synapse/SynapseContainerBuilder.ts
@@ -24,9 +24,7 @@ export class SynapseContainerBuilder extends ServiceContainerBuilder<SynapseCont
 
     async specificConfiguration(container: GenericContainer) {
         // Create mount dir, or empty it if it already exists
-        if (fs.existsSync(SynapseContainerBuilder.MOUNT_DIR)) {
-            fs.emptyDirSync(SynapseContainerBuilder.MOUNT_DIR)
-        } else {
+        if (!fs.existsSync(SynapseContainerBuilder.MOUNT_DIR)) {
             fs.mkdirSync(SynapseContainerBuilder.MOUNT_DIR)
         }
 


### PR DESCRIPTION
As of now, the pipeline is not working. Tests fail with the following error:
```
(node:6355) UnhandledPromiseRejectionWarning: Error: EACCES: permission denied, unlink '/tmp/synapse-mount/__pycache__/decentraland_password_auth_provider.cpython-38.pyc'
    at Object.unlinkSync (fs.js:1129:3)
    at rimrafSync (/tmp/repo/node_modules/fs-extra/lib/remove/rimraf.js:254:15)
    at /tmp/repo/node_modules/fs-extra/lib/remove/rimraf.js:291:39
    at Array.forEach (<anonymous>)
    at rmkidsSync (/tmp/repo/node_modules/fs-extra/lib/remove/rimraf.js:291:26)
    at rmdirSync (/tmp/repo/node_modules/fs-extra/lib/remove/rimraf.js:281:7)
    at Object.rimrafSync (/tmp/repo/node_modules/fs-extra/lib/remove/rimraf.js:252:7)
    at /tmp/repo/node_modules/fs-extra/lib/empty/index.js:39:12
    at Array.forEach (<anonymous>)
    at Object.emptyDirSync (/tmp/repo/node_modules/fs-extra/lib/empty/index.js:37:9)
    at SynapseContainerBuilder.specificConfiguration (/tmp/repo/test/integration/containers/synapse/SynapseContainerBuilder.ts:28:16)
    at SynapseContainerBuilder.start (/tmp/repo/test/integration/containers/commons/ServiceContainer.ts:32:14)
    at buildSynapse (/tmp/repo/test/integration/PasswordAuthProvider.spec.ts:162:42)
    at Context.<anonymous> (/tmp/repo/test/integration/PasswordAuthProvider.spec.ts:41:15)
    at callFn (/tmp/repo/node_modules/mocha/lib/runnable.js:372:21)
    at Test.Runnable.run (/tmp/repo/node_modules/mocha/lib/runnable.js:364:7)
    at Runner.runTest (/tmp/repo/node_modules/mocha/lib/runner.js:455:10)
    at /tmp/repo/node_modules/mocha/lib/runner.js:573:12
    at next (/tmp/repo/node_modules/mocha/lib/runner.js:369:14)
    at /tmp/repo/node_modules/mocha/lib/runner.js:379:7
    at next (/tmp/repo/node_modules/mocha/lib/runner.js:303:14)
    at /tmp/repo/node_modules/mocha/lib/runner.js:342:7
    at done (/tmp/repo/node_modules/mocha/lib/runnable.js:319:5)
    at /tmp/repo/node_modules/mocha/lib/runnable.js:377:11
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
```

We realized that we didn't have to empty the directory, since all copy/write operations would overwrite all existing files