### PR TITLE
Use Authorization header with the Matrix client API

### DIFF
--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -12,6 +12,7 @@ export async function login(synapseUrl: string, ethAddress: EthAddress, timestam
         baseUrl: synapseUrl,
         //@ts-ignore
         timelineSupport: true,
+        useAuthorizationHeader: true,
     })
 
     // Actual login


### PR DESCRIPTION
Using an Authorization header is often preferred to the default functionality of matrix-js-sdk using a query parameter for the access token.

See https://matrix-org.github.io/matrix-js-sdk/7.1.0/module-client.MatrixClient.html#MatrixClient