### PR TITLE
fix: avoid multiple calls to account data on start

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7863,7 +7863,6 @@
     },
     "node_modules/npm/node_modules/lodash._baseindexof": {
       "version": "3.1.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -7879,19 +7878,16 @@
     },
     "node_modules/npm/node_modules/lodash._bindcallback": {
       "version": "3.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._cacheindexof": {
       "version": "3.0.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._createcache": {
       "version": "3.1.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -7906,7 +7902,6 @@
     },
     "node_modules/npm/node_modules/lodash._getnative": {
       "version": "3.9.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -7924,7 +7919,6 @@
     },
     "node_modules/npm/node_modules/lodash.restparam": {
       "version": "3.6.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -19286,8 +19280,7 @@
         },
         "lodash._baseindexof": {
           "version": "3.1.0",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "lodash._baseuniq": {
           "version": "4.6.0",
@@ -19300,18 +19293,15 @@
         },
         "lodash._bindcallback": {
           "version": "3.0.1",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "lodash._cacheindexof": {
           "version": "3.0.2",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "lodash._createcache": {
           "version": "3.1.2",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "lodash._getnative": "^3.0.0"
           }
@@ -19323,8 +19313,7 @@
         },
         "lodash._getnative": {
           "version": "3.9.1",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "lodash._root": {
           "version": "3.0.1",
@@ -19338,8 +19327,7 @@
         },
         "lodash.restparam": {
           "version": "3.6.1",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "lodash.union": {
           "version": "4.6.0",

--- a/src/MessagingAPI.ts
+++ b/src/MessagingAPI.ts
@@ -3,6 +3,9 @@ import { ConversationCursor } from './ConversationCursor';
 
 export interface MessagingAPI {
 
+    /** Start listening to events */
+    listenToEvents(): void;
+
     /** Get all conversation the user has joined */
     getAllCurrentConversations(): { conversation: Conversation, unreadMessages: boolean }[]
 

--- a/src/SocialClient.ts
+++ b/src/SocialClient.ts
@@ -11,7 +11,7 @@ import { FriendsManagementClient } from './FriendsManagementClient';
 import { SocialAPI } from './SocialAPI';
 import { login } from './Utils';
 
-type ClientLoginOptions  = {
+type ClientLoginOptions = {
     pendingEventOrdering: string;
     disablePresence: boolean;
     initialSyncLimit: number;
@@ -29,9 +29,13 @@ export class SocialClient implements SocialAPI {
         this.friendsManagement = new FriendsManagementClient(matrixClient, this)
     }
 
+    listenToEvents(): void {
+        this.messaging.listenToEvents()
+    }
+
     static async loginToServer(synapseUrl: string, ethAddress: EthAddress, timestamp: Timestamp, authChain: AuthChain, options?: Partial<ClientLoginOptions> | undefined): Promise<SocialClient> {
         // Destructure options
-        const _options: ClientLoginOptions  = {
+        const _options: ClientLoginOptions = {
             pendingEventOrdering: 'detached', // Necessary for the SDK to work
             initialSyncLimit: 20, // This is the value that the Matrix React SDK uses
             disablePresence: false,
@@ -60,6 +64,9 @@ export class SocialClient implements SocialAPI {
 
         // Wait for initial sync
         await waitForInitialSync
+
+        // Starting listening to new events after initial sync
+        socialClient.listenToEvents()
 
         return socialClient
     }
@@ -96,7 +103,7 @@ export class SocialClient implements SocialAPI {
 
     //////             MESSAGING             //////
     getAllCurrentConversations(): { conversation: Conversation, unreadMessages: boolean }[] {
-       return this.messaging.getAllCurrentConversations()
+        return this.messaging.getAllCurrentConversations()
     }
 
     sendMessageTo(conversationId: ConversationId, message: string): Promise<MessageId> {


### PR DESCRIPTION
## Description

It prevents processing all events included in the initial sync (as room invites) by moving the event listener registration to the moment after it is finished. 