### PR TITLE
Fix: Get private chat messages

### DIFF
--- a/src/MessagingAPI.ts
+++ b/src/MessagingAPI.ts
@@ -36,7 +36,8 @@ export interface MessagingAPI {
      */
     getLastReadMessage(conversationId: ConversationId): BasicMessageInfo | undefined;
 
-    /** Returns a cursor located on the given message */
+    /** Returns a cursor located on the given message. If there is no given message, then it is 
+     * located at the end of the conversation. */
     getCursorOnMessage(conversationId: ConversationId, messageId?: MessageId, options?: CursorOptions): Promise<ConversationCursor>;
 
     /**

--- a/src/MessagingAPI.ts
+++ b/src/MessagingAPI.ts
@@ -37,7 +37,7 @@ export interface MessagingAPI {
     getLastReadMessage(conversationId: ConversationId): BasicMessageInfo | undefined;
 
     /** Returns a cursor located on the given message */
-    getCursorOnMessage(conversationId: ConversationId, messageId: MessageId, options?: CursorOptions): Promise<ConversationCursor>;
+    getCursorOnMessage(conversationId: ConversationId, messageId?: MessageId, options?: CursorOptions): Promise<ConversationCursor>;
 
     /**
      * Returns a cursor located on the last read message. If no messages were read, then

--- a/src/MessagingClient.ts
+++ b/src/MessagingClient.ts
@@ -65,15 +65,15 @@ export class MessagingClient implements MessagingAPI {
                         userIds: [this.matrixClient.getUserId(), otherId],
                         hasMessages: room.timeline.some(event => event.getType() === EventType.RoomMessage)
                     }
-            }
-        })
+                }
+            })
     }
 
     /** Get all conversation the user has joined */
     getAllConversationsWithUnreadMessages(): Conversation[] {
         return this.getAllCurrentConversations()
-        .filter(conv => conv.unreadMessages)
-        .map((conv): Conversation => conv.conversation)
+            .filter(conv => conv.unreadMessages)
+            .map((conv): Conversation => conv.conversation)
     }
 
     /** Get total number of unseen messages from all conversations the user has joined */

--- a/src/MessagingClient.ts
+++ b/src/MessagingClient.ts
@@ -188,8 +188,10 @@ export class MessagingClient implements MessagingAPI {
         return undefined
     }
 
-    /** Returns a cursor located on the given message */
-    getCursorOnMessage(conversationId: ConversationId, messageId: MessageId, options?: CursorOptions): Promise<ConversationCursor> {
+    /** Returns a cursor located on the given message. If there is no given message, then it is 
+     * located at the end of the conversation.
+    */
+    getCursorOnMessage(conversationId: ConversationId, messageId?: MessageId, options?: CursorOptions): Promise<ConversationCursor> {
         return ConversationCursor.build(this.matrixClient, conversationId, messageId, roomId => this.getLastReadMessage(roomId), options)
     }
 

--- a/src/SocialClient.ts
+++ b/src/SocialClient.ts
@@ -136,7 +136,7 @@ export class SocialClient implements SocialAPI {
         return this.messaging.getLastReadMessage(conversationId)
     }
 
-    getCursorOnMessage(conversationId: ConversationId, messageId: MessageId, options?: CursorOptions): Promise<ConversationCursor> {
+    getCursorOnMessage(conversationId: ConversationId, messageId?: MessageId, options?: CursorOptions): Promise<ConversationCursor> {
         return this.messaging.getCursorOnMessage(conversationId, messageId, options)
     }
 

--- a/test/integration/ConversationCursor.spec.ts
+++ b/test/integration/ConversationCursor.spec.ts
@@ -40,6 +40,34 @@ describe('Integration - Conversation cursor', () => {
         expect(cursor.canExtendInDirection(CursorDirection.BACKWARDS)).to.be.true
     })
 
+    it(`When using a cursor on an undefined message, the reported messages are the expected`, async () => {
+        const sender = await testEnv.getRandomClient()
+        const receiver = await testEnv.getRandomClient()
+
+        // Create a conversation
+        const { id: conversationId } = await sender.createDirectConversation(receiver.getUserId())
+
+        // Send messages
+        await sendMessages(sender, conversationId, 0, 10)
+        await sendMessages(sender, conversationId, 11, 9)
+
+        // Wait for sync
+        await sleep('1s')
+
+        // Get cursor on specific message
+        const cursor = await receiver.getCursorOnMessage(conversationId, undefined, { initialSize: 3 })
+
+        // Read the messages
+        const messages = cursor.getMessages()
+
+        // Assert that the messages are the expected ones (the last ones)
+        assertMessagesAre(messages, 17, 19)
+
+        // Make sure that extension possibilities are correct
+        expect(cursor.canExtendInDirection(CursorDirection.FORWARDS)).to.be.false
+        expect(cursor.canExtendInDirection(CursorDirection.BACKWARDS)).to.be.true
+    })
+
     it(`When using a cursor on the last read message, the reported messages are the expected`, async () => {
         const sender = await testEnv.getRandomClient()
         const receiver = await testEnv.getRandomClient()


### PR DESCRIPTION
Make param `messageId` of the method `getCursorOnMessage()` optional in order to return a cursor located on the given message or at the end of the conversation when there is no given message.