### PR TITLE
fix: infinite loop in searchChannel func

### DIFF
--- a/src/MessagingClient.ts
+++ b/src/MessagingClient.ts
@@ -402,7 +402,7 @@ export class MessagingClient implements MessagingAPI {
                 })
                 publicRooms.push(...res.chunk)
                 nextBatch = res.next_batch
-            } while (publicRooms.length < limit || !res.next_batch)
+            } while (publicRooms.length < limit && res.next_batch)
 
             return {
                 channels: publicRooms.map(


### PR DESCRIPTION
We stay in the loop when `publicRooms < limit` and `nextBatch !== undefined`, otherwise we break the loop

Closes #66 