### PR TITLE
fix: avoid setting a conversation when already exists

### DIFF
--- a/src/MessagingClient.ts
+++ b/src/MessagingClient.ts
@@ -591,6 +591,7 @@ export class MessagingClient implements MessagingAPI {
         // However, we only support having one direct room to each user, so the list will only have one element
         const mDirectEvent = this.matrixClient.getAccountData('m.direct')
         const directRoomMap = mDirectEvent ? mDirectEvent.getContent() : {}
+        if (directRoomMap[userId].includes(roomId)) return;
         directRoomMap[userId] = [roomId]
         await this.matrixClient.setAccountData('m.direct', directRoomMap)
     }


### PR DESCRIPTION
This PR:
- avoid setting a conversation with a friend when it's already set. 
