### PR TITLE
feat: get conversation by channel name

### DIFF
--- a/src/MessagingAPI.ts
+++ b/src/MessagingAPI.ts
@@ -92,6 +92,13 @@ export interface MessagingAPI {
      */
     getChannel(roomId: string): Conversation | undefined
 
+    /**
+     * Get the conversation for a channel by its name.
+     * @param alias the name of the channel.
+     * @returns `Promise<Conversation>` if it exists | `Promise<undefined>` if it does not exist.
+     */
+    getChannelByName(alias: string): Promise<Conversation | undefined>
+
     /** Join a channel */
     joinChannel(roomIdOrChannelAlias: string): Promise<void>
 

--- a/src/SocialClient.ts
+++ b/src/SocialClient.ts
@@ -265,6 +265,10 @@ export class SocialClient implements SocialAPI {
         return this.messaging.getChannel(roomId)
     }
 
+    getChannelByName(alias: string): Promise<Conversation | undefined> {
+        return this.messaging.getChannelByName(alias)
+    }
+
     getOrCreateChannel(channelName: string, userIds: string[]): Promise<GetOrCreateConversationResponse> {
         return this.messaging.getOrCreateChannel(channelName, userIds)
     }


### PR DESCRIPTION
To prevent the creation of a channel in case a user who does not have permission (`users_allowed_to_create_channels`) to create it executes the `/join` command, we need first check if the channel exists or not.