### PR TITLE
fix: set user's account data all at once

### DIFF
--- a/src/MessagingAPI.ts
+++ b/src/MessagingAPI.ts
@@ -39,6 +39,7 @@ export interface MessagingAPI {
     getProfileInfo(userId: string): Promise<ProfileInfo>
 
     getMemberInfo(roomId: string, userId: string): ProfileInfo
+
     /**
      * Send a text message  to a conversation.
      * Returns the message id

--- a/src/MessagingClient.ts
+++ b/src/MessagingClient.ts
@@ -67,7 +67,7 @@ export class MessagingClient implements MessagingAPI {
         // Listen to when the sync is finishes, and join all rooms I was invited to
         const resolveOnSync = async (state: SyncState) => {
             if (state === 'SYNCING') {
-                const members = []
+                const members: RoomMember[] = []
                 const rooms = this.getAllRooms()
                 const join: Promise<void>[] = rooms
                     .filter(room => room.getMyMembership() === 'invite') // Consider rooms that I have been invited to
@@ -705,8 +705,6 @@ export class MessagingClient implements MessagingAPI {
                 }
             }
         })
-
-        console.log(`JULIETA addDirectRoomToUser - setAccountData directRoomMap: ${JSON.stringify(directRoomMap)}`)
 
         await this.matrixClient.setAccountData('m.direct', directRoomMap)
     }

--- a/src/MessagingClient.ts
+++ b/src/MessagingClient.ts
@@ -74,7 +74,7 @@ export class MessagingClient implements MessagingAPI {
                     .map(room => {
                         const member = room.getMember(this.socialClient.getUserId())
                         if (member) {
-                            members.push()
+                            members.push(member)
                         }
                         return this.joinRoom(member)
                     })

--- a/src/MessagingClient.ts
+++ b/src/MessagingClient.ts
@@ -110,7 +110,7 @@ export class MessagingClient implements MessagingAPI {
         this.matrixClient.on(RoomMemberEvent.Membership, async (_, member) => {
             if (member.membership === 'invite' && member.userId === this.socialClient.getUserId()) {
                 await waitSyncToFinish(this.matrixClient)
-                //TODO JULI:
+
                 await this.addDirectRoomsToUser([member])
 
                 await this.joinRoom(member)
@@ -400,10 +400,11 @@ export class MessagingClient implements MessagingAPI {
     /** Get or create a direct conversation with the given user */
     async createDirectConversation(userId: SocialId): Promise<Conversation> {
         const { conversation, created } = await this.getOrCreateConversation(ConversationType.DIRECT, [userId])
-        // TODO JULI!
+
         if (created) {
             await this.addDirectRoomToUser(userId, conversation.id)
         }
+
         return conversation
     }
 
@@ -634,11 +635,11 @@ export class MessagingClient implements MessagingAPI {
         return this.getAllRooms().filter(room => room.getCanonicalAlias() === alias)[0]
     }
 
-    // TODO JULI!
     private async joinRoom(member: RoomMember | null): Promise<void> {
         if (!member) {
             return
         }
+
         await this.matrixClient.joinRoom(member.roomId)
     }
 
@@ -687,7 +688,6 @@ export class MessagingClient implements MessagingAPI {
         await this.matrixClient.setAccountData('m.direct', directRoomMap)
     }
 
-    // TODO JULI!
     private async addDirectRoomsToUser(members: RoomMember[]): Promise<void> {
         // The documentation specifies that we should store a map from user to direct rooms in the 'm.direct' event
         // However, we only support having one direct room to each user, so the list will only have one element

--- a/test/integration/FriendsManagementClient.spec.ts
+++ b/test/integration/FriendsManagementClient.spec.ts
@@ -11,6 +11,7 @@ globalThis.global = globalThis as any
 chai.use(sinonChai)
 const expect = chai.expect
 
+// TODO: We should add a test for the concurrent update errors #97
 describe('Integration - Friends Management Client', () => {
 
     const testEnv: TestEnvironment = loadTestEnvironment()


### PR DESCRIPTION
Closes #97 

We currently have concurrent update errors for different users when there are multiple rooms trying to set up `m.direct` on the initial sync.

So, to avoid the concurrent update error, we decided to set the user's `m.direct` events all at once with a single request, which allows us to lighten the number of updates and thus reduce the concurrent update error.