### PR TITLE
feat: add optional message param for friend requests

### DIFF
--- a/etc/dcl-social-client.api.md
+++ b/etc/dcl-social-client.api.md
@@ -204,7 +204,7 @@ export interface SocialAPI extends FriendsManagementAPI, MessagingAPI, SessionMa
 // @public (undocumented)
 export class SocialClient implements SocialAPI {
     // (undocumented)
-    addAsFriend(userId: SocialId, message?: string): Promise<void>;
+    addAsFriend(userId: SocialId, message?: string | undefined): Promise<void>;
     // (undocumented)
     approveFriendshipRequestFrom(userId: SocialId): Promise<void>;
     // (undocumented)
@@ -284,7 +284,7 @@ export class SocialClient implements SocialAPI {
     // (undocumented)
     onFriendshipDeletion(listener: (deletedBy: SocialId) => void): void;
     // (undocumented)
-    onFriendshipRequest(listener: (requestedBy: SocialId, message?: string) => void): void;
+    onFriendshipRequest(listener: (requestedBy: SocialId, message?: string | undefined) => void): void;
     // (undocumented)
     onFriendshipRequestApproval(listener: (approvedBy: SocialId) => void): void;
     // (undocumented)

--- a/etc/dcl-social-client.api.md
+++ b/etc/dcl-social-client.api.md
@@ -115,6 +115,7 @@ export type FriendshipRequest = {
     from: SocialId;
     to: SocialId;
     createdAt: number;
+    message?: string;
 };
 
 // @public (undocumented)
@@ -203,7 +204,7 @@ export interface SocialAPI extends FriendsManagementAPI, MessagingAPI, SessionMa
 // @public (undocumented)
 export class SocialClient implements SocialAPI {
     // (undocumented)
-    addAsFriend(userId: SocialId): Promise<void>;
+    addAsFriend(userId: SocialId, message?: string): Promise<void>;
     // (undocumented)
     approveFriendshipRequestFrom(userId: SocialId): Promise<void>;
     // (undocumented)
@@ -283,7 +284,7 @@ export class SocialClient implements SocialAPI {
     // (undocumented)
     onFriendshipDeletion(listener: (deletedBy: SocialId) => void): void;
     // (undocumented)
-    onFriendshipRequest(listener: (requestedBy: SocialId) => void): void;
+    onFriendshipRequest(listener: (requestedBy: SocialId, message?: string) => void): void;
     // (undocumented)
     onFriendshipRequestApproval(listener: (approvedBy: SocialId) => void): void;
     // (undocumented)

--- a/src/FriendsManagementAPI.ts
+++ b/src/FriendsManagementAPI.ts
@@ -8,13 +8,13 @@ export interface FriendsManagementAPI {
     getPendingRequests(): FriendshipRequest[]
     isUserMyFriend(userId: SocialId): boolean
 
-    addAsFriend(userId: SocialId): Promise<void>
+    addAsFriend(userId: SocialId, message?: string): Promise<void>
     deleteFriendshipWith(userId: SocialId): Promise<void>
     approveFriendshipRequestFrom(userId: SocialId): Promise<void>
     rejectFriendshipRequestFrom(userId: SocialId): Promise<void>
     cancelFriendshipRequestTo(userId: SocialId): Promise<void>
 
-    onFriendshipRequest(listener: (requestedBy: SocialId) => void): void
+    onFriendshipRequest(listener: (requestedBy: SocialId, message?: string) => void): void
     onFriendshipRequestCancellation(listener: (canceledBy: SocialId) => void): void
     onFriendshipRequestRejection(listener: (rejectedBy: SocialId) => void): void
     onFriendshipRequestApproval(listener: (approvedBy: SocialId) => void): void

--- a/src/FriendsManagementAPI.ts
+++ b/src/FriendsManagementAPI.ts
@@ -8,13 +8,13 @@ export interface FriendsManagementAPI {
     getPendingRequests(): FriendshipRequest[]
     isUserMyFriend(userId: SocialId): boolean
 
-    addAsFriend(userId: SocialId, message?: string): Promise<void>
+    addAsFriend(userId: SocialId, message?: string | undefined): Promise<void>
     deleteFriendshipWith(userId: SocialId): Promise<void>
     approveFriendshipRequestFrom(userId: SocialId): Promise<void>
     rejectFriendshipRequestFrom(userId: SocialId): Promise<void>
     cancelFriendshipRequestTo(userId: SocialId): Promise<void>
 
-    onFriendshipRequest(listener: (requestedBy: SocialId, message?: string) => void): void
+    onFriendshipRequest(listener: (requestedBy: SocialId, message?: string | undefined) => void): void
     onFriendshipRequestCancellation(listener: (canceledBy: SocialId) => void): void
     onFriendshipRequestRejection(listener: (rejectedBy: SocialId) => void): void
     onFriendshipRequestApproval(listener: (approvedBy: SocialId) => void): void

--- a/src/FriendsManagementClient.ts
+++ b/src/FriendsManagementClient.ts
@@ -88,10 +88,22 @@ export class FriendsManagementClient implements FriendsManagementAPI {
             .filter(([, status]) => FriendsManagementClient.PENDING_STATUSES.includes(status))
             .map(([room, status]) => {
                 const other = room.guessDMUserId()
+                const event = getLastFriendshipEventInRoom(room)
+                const message: string | undefined = event?.getContent().message
                 if (status === FriendshipStatus.REQUEST_SENT_BY_ME_PENDING) {
-                    return { from: this.socialClient.getUserId(), to: other, createdAt: room.timeline[0].getTs() }
+                    return {
+                        from: this.socialClient.getUserId(),
+                        to: other,
+                        createdAt: room.timeline[0].getTs(),
+                        message
+                    }
                 } else {
-                    return { to: this.socialClient.getUserId(), from: other, createdAt: room.timeline[0].getTs() }
+                    return {
+                        to: this.socialClient.getUserId(),
+                        from: other,
+                        createdAt: room.timeline[0].getTs(),
+                        message
+                    }
                 }
             })
     }

--- a/src/FriendsManagementClient.ts
+++ b/src/FriendsManagementClient.ts
@@ -89,7 +89,7 @@ export class FriendsManagementClient implements FriendsManagementAPI {
             .map(([room, status]) => {
                 const other = room.guessDMUserId()
                 const event = getLastFriendshipEventInRoom(room)
-                const message: string | undefined = event?.getContent().message
+                const message: string | undefined = event?.getContent().message //
                 if (status === FriendshipStatus.REQUEST_SENT_BY_ME_PENDING) {
                     return {
                         from: this.socialClient.getUserId(),

--- a/src/FriendsManagementClient.ts
+++ b/src/FriendsManagementClient.ts
@@ -87,10 +87,13 @@ export class FriendsManagementClient implements FriendsManagementAPI {
             .map(room => [room, this.getFriendshipStatusInRoom(room)] as [Room, FriendshipStatus])
             .filter(([, status]) => FriendsManagementClient.PENDING_STATUSES.includes(status))
             .map(([room, status]) => {
+                const sentByMe = status === FriendshipStatus.REQUEST_SENT_BY_ME_PENDING
                 const other = room.guessDMUserId()
-                const event = getLastFriendshipEventInRoom(room)
-                const message: string | undefined = event?.getContent().message //
-                if (status === FriendshipStatus.REQUEST_SENT_BY_ME_PENDING) {
+                // we ask for the friendship event of the requester
+                const key = sentByMe ? this.socialClient.getUserId() : other
+                const event = getLastFriendshipEventInRoom(room, key)
+                const message: string | undefined = event?.getContent().message
+                if (sentByMe) {
                     return {
                         from: this.socialClient.getUserId(),
                         to: other,

--- a/src/FriendsManagementClient.ts
+++ b/src/FriendsManagementClient.ts
@@ -113,7 +113,7 @@ export class FriendsManagementClient implements FriendsManagementAPI {
         return friends.includes(userId)
     }
 
-    async addAsFriend(userId: SocialId, message?: string): Promise<void> {
+    async addAsFriend(userId: SocialId, message?: string | undefined): Promise<void> {
         return this.actByStatus(
             userId,
             // Send request

--- a/src/FriendsManagementClient.ts
+++ b/src/FriendsManagementClient.ts
@@ -169,7 +169,7 @@ export class FriendsManagementClient implements FriendsManagementAPI {
         )
     }
 
-    onFriendshipRequest(listener: (requestedBy: SocialId, message?: string) => void): void {
+    onFriendshipRequest(listener: (requestedBy: SocialId, message?: string | undefined) => void): void {
         return this.listenToEvent(FriendshipEvent.REQUEST, listener)
     }
 

--- a/src/SocialClient.ts
+++ b/src/SocialClient.ts
@@ -244,7 +244,7 @@ export class SocialClient implements SocialAPI {
         return this.friendsManagement.isUserMyFriend(userId)
     }
 
-    addAsFriend(userId: SocialId, message?: string): Promise<void> {
+    addAsFriend(userId: SocialId, message?: string | undefined): Promise<void> {
         return this.friendsManagement.addAsFriend(userId, message)
     }
 
@@ -264,7 +264,7 @@ export class SocialClient implements SocialAPI {
         return this.friendsManagement.cancelFriendshipRequestTo(userId)
     }
 
-    onFriendshipRequest(listener: (requestedBy: SocialId, message?: string) => void): void {
+    onFriendshipRequest(listener: (requestedBy: SocialId, message?: string | undefined) => void): void {
         return this.friendsManagement.onFriendshipRequest(listener)
     }
 

--- a/src/SocialClient.ts
+++ b/src/SocialClient.ts
@@ -244,8 +244,8 @@ export class SocialClient implements SocialAPI {
         return this.friendsManagement.isUserMyFriend(userId)
     }
 
-    addAsFriend(userId: SocialId): Promise<void> {
-        return this.friendsManagement.addAsFriend(userId)
+    addAsFriend(userId: SocialId, message?: string): Promise<void> {
+        return this.friendsManagement.addAsFriend(userId, message)
     }
 
     deleteFriendshipWith(userId: SocialId): Promise<void> {
@@ -264,7 +264,7 @@ export class SocialClient implements SocialAPI {
         return this.friendsManagement.cancelFriendshipRequestTo(userId)
     }
 
-    onFriendshipRequest(listener: (requestedBy: SocialId) => void): void {
+    onFriendshipRequest(listener: (requestedBy: SocialId, message?: string) => void): void {
         return this.friendsManagement.onFriendshipRequest(listener)
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -70,6 +70,7 @@ export type FriendshipRequest = {
     from: SocialId
     to: SocialId
     createdAt: number
+    message?: string
 }
 
 export type UpdateUserStatus = {

--- a/test/integration/FriendsManagementClient.spec.ts
+++ b/test/integration/FriendsManagementClient.spec.ts
@@ -264,7 +264,7 @@ describe('Integration - Friends Management Client', () => {
         expect(fromPendingRequest.to).to.equal(to.getUserId())
         expect(fromPendingRequest.createdAt).not.to.equal(null)
         expect(typeof fromPendingRequest.createdAt).to.equal(typeof 1)
-        expect(fromPendingRequest.message).to.equal(toPendingRequest.message)
+        assertMessageFromPendingRequest(from, to, fromPendingRequest.message)
     }
 
     function assertNoPendingRequests(...clients: SocialClient[]): void {


### PR DESCRIPTION
Closes #109 

Branch for new friend request feature. Find more info [here](https://www.notion.so/decentraland/RFC-Technical-Assessment-New-Friend-Request-24e8259c26544df68c1f715edbb1b896).

Long story short: we're Introducing an optional attached message to the friend request.