### PR TITLE
fix: join channel by name

### DIFF
--- a/src/MessagingClient.ts
+++ b/src/MessagingClient.ts
@@ -446,9 +446,22 @@ export class MessagingClient implements MessagingAPI {
         }
     }
 
-    /** Join a channel */
+    /**
+     * Join a channel
+     * @param roomIdOrChannelAlias the room id or name of the channel.
+     */
     async joinChannel(roomIdOrChannelAlias: string): Promise<void> {
         try {
+            // The doc says you can pass the room ID or room alias to join, but that's not true -.-
+            // Technically we can validate if we have received a name with the regular expression
+            const isAlias = validateRegexChannelId(roomIdOrChannelAlias)
+            if (isAlias) {
+                const room = await this.getChannelByName(roomIdOrChannelAlias)
+                if (!room) {
+                    throw new ChannelsError(ChannelErrorKind.JOIN)
+                }
+                roomIdOrChannelAlias = room.id
+            }
             await this.matrixClient.joinRoom(roomIdOrChannelAlias)
         } catch (error) {
             throw new ChannelsError(ChannelErrorKind.JOIN)

--- a/test/integration/MessagingClient.spec.ts
+++ b/test/integration/MessagingClient.spec.ts
@@ -374,9 +374,38 @@ describe('Integration - Messaging Client', () => {
 
       const { conversation } = await client.getOrCreateChannel('channel-name', [])
 
-      // TODO: We should add an aditional test where the user joins the channel with the alias!
       // Join channel
       await client.joinChannel(conversation.id)
+
+      // Wait for sync
+      await sleep('1s')
+
+      // Make sure that the spy was called
+      expect(spy).to.have.been.calledOnce
+
+      // Leave channel
+      await client.leaveChannel(conversation.id)
+
+      // Wait for sync
+      await sleep('1s')
+
+      // Make sure that the spy was called
+      expect(spy).to.have.been.calledTwice
+    })
+
+    it ('Listen for events related to the membership updates a room receives during the sync', async () => {
+      const client = await testEnv.getRandomClient()
+
+      // Prepare spy
+      const spy = sinon.spy()
+
+      // Set listener
+      client.onChannelMembership(spy)
+
+      const { conversation } = await client.getOrCreateChannel('channel-name', [])
+
+      // Join channel by name
+      await client.joinChannel('channel-name')
 
       // Wait for sync
       await sleep('1s')


### PR DESCRIPTION
The doc says you can pass the room ID or room alias to join, but that's not true -.-. Technically we can validate if we have received a name with the regular expression, if so then we go get the room id and then join the channel