### PR TITLE
fix: filter out instead of remove

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@dcl/crypto": "^3.0.1",
+        "events": "^3.3.0",
         "matrix-js-sdk": "^21.0.0"
       },
       "devDependencies": {
@@ -3078,6 +3079,14 @@
       "engines": {
         "node": ">=6.5.0",
         "npm": ">=3"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "engines": {
+        "node": ">=0.8.x"
       }
     },
     "node_modules/evp_bytestokey": {
@@ -14686,6 +14695,11 @@
         "is-hex-prefixed": "1.0.0",
         "strip-hex-prefix": "1.0.0"
       }
+    },
+    "events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
     },
     "evp_bytestokey": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   "homepage": "https://github.com/decentraland/matrix-client#readme",
   "dependencies": {
     "@dcl/crypto": "^3.0.1",
+    "events": "^3.3.0",
     "matrix-js-sdk": "^21.0.0"
   },
   "devDependencies": {

--- a/src/ConversationCursor.ts
+++ b/src/ConversationCursor.ts
@@ -84,7 +84,7 @@ export class ConversationCursor {
 
             let timelineSet = getMessagesAndFriendshipEventsTimelineSetFromRoom(userId, room, limit)
 
-            // We filter all friendship events to only keep those that are requests, have a message body
+            // We filter out all friendship events to only keep those that are requests, have a message body
             // and have a state key, which indicates that the event was sent by the requester.
             const eventsToFilterOut = timelineSet
                 .getLiveTimeline()

--- a/src/ConversationCursor.ts
+++ b/src/ConversationCursor.ts
@@ -89,13 +89,16 @@ export class ConversationCursor {
             const eventsToFilterOut = timelineSet
                 .getLiveTimeline()
                 .getEvents()
-                .filter(event => {
-                    event.getType() === 'org.decentraland.friendship' &&
-                        (event.getContent().type !== 'request' || !event.getStateKey() || !event.getContent().body)
-                })
+                .filter(
+                    event =>
+                        event.event.type === 'org.decentraland.friendship' &&
+                        (event.event.content?.type !== 'request' ||
+                            !event.event.state_key ||
+                            !event.event.content?.body)
+                )
 
             eventsToFilterOut.forEach(event => {
-                timelineSet.removeEvent(event.getId())
+              timelineSet.getTimelineForEvent(event.getId())?.removeEvent(event.getId())
             })
 
             const window = new TimelineWindow(client, timelineSet, { windowLimit: limit })

--- a/src/ConversationCursor.ts
+++ b/src/ConversationCursor.ts
@@ -29,9 +29,7 @@ export class ConversationCursor {
     getMessages(): TextMessage[] {
         const latestReadTimestamp: Timestamp | undefined = this.lastReadMessageTimestampFetch(this.roomId)?.timestamp
 
-        // We only want messages from events that are of type m.room.message or org.decentraland.friendship and have a message body and a state key
         const events = this.window.getEvents()
-
         return events.map(event =>
             buildTextMessage(
                 event,
@@ -112,14 +110,12 @@ export class ConversationCursor {
             let gotResults = true
             while (windowSize < initialSize && gotResults) {
                 gotResults = await window.paginate(EventTimeline.BACKWARDS, initialSize - windowSize)
-
                 windowSize = window.getEvents().length
             }
 
             gotResults = true
             while (windowSize < initialSize && gotResults) {
                 gotResults = await window.paginate(EventTimeline.FORWARDS, initialSize - windowSize)
-
                 windowSize = window.getEvents().length
             }
 

--- a/src/ConversationCursor.ts
+++ b/src/ConversationCursor.ts
@@ -86,7 +86,7 @@ export class ConversationCursor {
 
             // We filter all friendship events to only keep those that are requests, have a message body
             // and have a state key, which indicates that the event was sent by the requester.
-            timelineSet
+            const eventsToFilterOut = timelineSet
                 .getLiveTimeline()
                 .getEvents()
                 .filter(
@@ -96,11 +96,10 @@ export class ConversationCursor {
                             !event.event.state_key ||
                             !event.event.content?.body)
                 )
-                .forEach(event => {
-                    if (typeof event.event.event_id === 'string') {
-                        timelineSet.removeEvent(event.event.event_id)
-                    }
-                })
+
+            eventsToFilterOut.forEach(event => {
+                timelineSet.removeEvent(event.getId())
+            })
 
             const window = new TimelineWindow(client, timelineSet, { windowLimit: limit })
             await window.load(initialEventId, initialSize)

--- a/src/ConversationCursor.ts
+++ b/src/ConversationCursor.ts
@@ -89,13 +89,10 @@ export class ConversationCursor {
             const eventsToFilterOut = timelineSet
                 .getLiveTimeline()
                 .getEvents()
-                .filter(
-                    event =>
-                        event.event.type === 'org.decentraland.friendship' &&
-                        (event.event.content?.type !== 'request' ||
-                            !event.event.state_key ||
-                            !event.event.content?.body)
-                )
+                .filter(event => {
+                    event.getType() === 'org.decentraland.friendship' &&
+                        (event.getContent().type !== 'request' || !event.getStateKey() || !event.getContent().body)
+                })
 
             eventsToFilterOut.forEach(event => {
                 timelineSet.removeEvent(event.getId())

--- a/src/ConversationCursor.ts
+++ b/src/ConversationCursor.ts
@@ -3,7 +3,7 @@ import { TimelineWindow } from 'matrix-js-sdk/lib/timeline-window'
 import { EventTimeline } from 'matrix-js-sdk/lib/models/event-timeline'
 import {
     buildTextMessage,
-    calculateEventsToFilterOut,
+    eventsToFilterOut,
     getMessagesAndFriendshipEventsTimelineSetFromRoom,
     waitSyncToFinish
 } from './Utils'
@@ -36,14 +36,16 @@ export class ConversationCursor {
 
         // We filter out all friendship events to only keep those that are requests, have a message body
         // and have a state key, which indicates that the event was sent by the requester.
-        const events = this.window
-            .getEvents()
-            .filter(
-                event =>
-                    event.event.type === 'm.room.message' ||
-                    (event.event.type === 'org.decentraland.friendship' &&
-                        (event.event.content?.type === 'request' || event.event.state_key || event.event.content?.body))
+        const events = this.window.getEvents().filter(event => {
+            return (
+                event.getType() === 'm.room.message' ||
+                (event.getType() === 'org.decentraland.friendship' &&
+                    event.event.content?.type === 'request' &&
+                    event.event.state_key &&
+                    event.event.content?.body)
             )
+        })
+
         return events.map(event =>
             buildTextMessage(
                 event,
@@ -98,29 +100,29 @@ export class ConversationCursor {
 
             let timelineSet = getMessagesAndFriendshipEventsTimelineSetFromRoom(userId, room, limit)
 
-            let eventsToFilterOut = calculateEventsToFilterOut(timelineSet.getLiveTimeline().getEvents())
+            let eventsToFilter = eventsToFilterOut(timelineSet.getLiveTimeline().getEvents())
 
             const window = new TimelineWindow(client, timelineSet, { windowLimit: limit })
             await window.load(initialEventId, initialSize)
 
             // It could happen that the initial size of the window isn't respected. That's why we will try to fix it
-            let windowSize = window.getEvents().length - eventsToFilterOut
+            let windowSize = window.getEvents().length - eventsToFilter
             let gotResults = true
             while (windowSize < initialSize && gotResults) {
                 gotResults = await window.paginate(EventTimeline.BACKWARDS, initialSize - windowSize)
 
-                eventsToFilterOut = calculateEventsToFilterOut(window.getEvents())
+                eventsToFilter = eventsToFilterOut(window.getEvents())
 
-                windowSize = window.getEvents().length - eventsToFilterOut
+                windowSize = window.getEvents().length - eventsToFilter
             }
 
             gotResults = true
             while (windowSize < initialSize && gotResults) {
                 gotResults = await window.paginate(EventTimeline.FORWARDS, initialSize - windowSize)
 
-                eventsToFilterOut = calculateEventsToFilterOut(window.getEvents())
+                eventsToFilter = eventsToFilterOut(window.getEvents())
 
-                windowSize = window.getEvents().length - eventsToFilterOut
+                windowSize = window.getEvents().length - eventsToFilter
             }
 
             return new ConversationCursor(roomId, window, lastReadMessageTimestampFetch)

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -222,15 +222,7 @@ export function eventsToFilterOut(events: MatrixEvent[]): number {
     return events.filter(event => {
         return (
             event.event.type === 'org.decentraland.friendship' &&
-            (event.event.content?.type !== 'request' ||
-                isEmptyString(event.event.state_key) ||
-                isEmptyString(event.event.content?.body) ||
-                !event.event.state_key ||
-                !event.event.content?.body)
+            (event.event.content?.type !== 'request' || !event.event.state_key || !event.event.content?.body)
         )
     }).length
-}
-
-function isEmptyString(str?: string): boolean {
-    return str?.trim() === '' || !str
 }

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -216,11 +216,21 @@ const GET_MESSAGES_AND_FRIENDSHIP_EVENTS_FILTER = (userId: SocialId, limit?: num
  * or does not have a state key.
  * @param events
  * @returns the length of the filtered array
+ * @internal
  */
-export function calculateEventsToFilterOut(events: MatrixEvent[]): number {
-    return events.filter(
-        event =>
+export function eventsToFilterOut(events: MatrixEvent[]): number {
+    return events.filter(event => {
+        return (
             event.event.type === 'org.decentraland.friendship' &&
-            (event.event.content?.type !== 'request' || !event.event.state_key || !event.event.content?.body)
-    ).length
+            (event.event.content?.type !== 'request' ||
+                isEmptyString(event.event.state_key) ||
+                isEmptyString(event.event.content?.body) ||
+                !event.event.state_key ||
+                !event.event.content?.body)
+        )
+    }).length
+}
+
+function isEmptyString(str?: string): boolean {
+    return str?.trim() === '' || !str
 }

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -210,3 +210,17 @@ const GET_MESSAGES_AND_FRIENDSHIP_EVENTS_FILTER = (userId: SocialId, limit?: num
             }
         }
     })
+
+/**
+ * We filter out all friendship events that are not requests, does not have a message body
+ * or does not have a state key.
+ * @param events
+ * @returns the length of the filtered array
+ */
+export function calculateEventsToFilterOut(events: MatrixEvent[]): number {
+    return events.filter(
+        event =>
+            event.event.type === 'org.decentraland.friendship' &&
+            (event.event.content?.type !== 'request' || !event.event.state_key || !event.event.content?.body)
+    ).length
+}

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -212,17 +212,20 @@ const GET_MESSAGES_AND_FRIENDSHIP_EVENTS_FILTER = (userId: SocialId, limit?: num
     })
 
 /**
- * We filter out all friendship events that are not requests, does not have a message body
- * or does not have a state key.
+ * We only care about events that are of type `m.room.message`
+ * or `org.decentraland.friendship` that have a message body and a state key, so we filter out all other events.
  * @param events
- * @returns the length of the filtered array
+ * @returns the filtered array
  * @internal
  */
-export function eventsToFilterOut(events: MatrixEvent[]): number {
+export function filterEvents(events: MatrixEvent[]): MatrixEvent[] {
     return events.filter(event => {
         return (
-            event.event.type === 'org.decentraland.friendship' &&
-            (event.event.content?.type !== 'request' || !event.event.state_key || !event.event.content?.body)
+            event.getType() === 'm.room.message' ||
+            (event.getType() === 'org.decentraland.friendship' &&
+                event.event.content?.type === 'request' &&
+                event.event.state_key &&
+                event.event.content?.body)
         )
-    }).length
+    })
 }

--- a/test/integration/ConversationCursor.spec.ts
+++ b/test/integration/ConversationCursor.spec.ts
@@ -271,17 +271,24 @@ describe('Integration - Conversation cursor', () => {
         await sleep('1s')
 
         // Get cursor on last message
-        const cursor = (await receiver.getCursorOnLastMessage(conversationId))!
+        const cursorReceiver = (await receiver.getCursorOnLastMessage(conversationId))!
+        const cursorSender = (await sender.getCursorOnLastMessage(conversationId))!
 
-        expect(cursor).to.be.not.empty
+        expect(cursorReceiver).to.be.not.empty
+        expect(cursorSender).to.be.not.empty
 
         // Read the messages
-        const messages = cursor.getMessages()
-        const requestMesssage = messages.filter(msg => msg.text.includes(message))
+        const messagesReceiver = cursorReceiver.getMessages()
+        const messagesSender = cursorSender.getMessages()
+
+        const requestMesssageReceiver = messagesReceiver.filter(msg => msg.text.includes(message))
+        const requestMesssageSender = messagesSender.filter(msg => msg.text.includes(message))
 
         // Make sure we read all the expected messages
-        expect(messages.length).to.be.equal(5)
-        expect(requestMesssage.length).to.be.equal(1)
+        expect(messagesReceiver.length).to.be.equal(5)
+        expect(messagesSender.length).to.be.equal(5)
+        expect(requestMesssageReceiver.length).to.be.equal(1)
+        expect(requestMesssageSender.length).to.be.equal(1)
     })
 
     it(`When the cursor is moved, the reported messages are also moved along with the message sent in the request event`, async () => {

--- a/test/integration/ConversationCursor.spec.ts
+++ b/test/integration/ConversationCursor.spec.ts
@@ -305,7 +305,7 @@ describe('Integration - Conversation cursor', () => {
         // Get conversation
         const { id: conversationId } = await sender.createDirectConversation(receiver.getUserId())
 
-        // Send messages
+        // Send messages (from Message #0 to Message #3)
         await sendMessages(sender, conversationId, 0, 4)
 
         // Wait for sync
@@ -330,7 +330,7 @@ describe('Integration - Conversation cursor', () => {
         const requestMesssageYes = secondPage.filter(msg => msg.text.includes(message))
 
         // Make sure we read all the expected messages
-        expect(secondPage.length).to.be.equal(3)
+        expect(secondPage.length).to.be.equal(2)
         expect(requestMesssageYes.length).to.be.equal(1)
     })
 

--- a/test/integration/ConversationCursor.spec.ts
+++ b/test/integration/ConversationCursor.spec.ts
@@ -250,7 +250,7 @@ describe('Integration - Conversation cursor', () => {
         assertMessagesAre(cursor.getMessages(), 5, 14)
     })
 
-    it(`When the cursor is used, the reported messages are as expected, including the message sent in the request event`, async () => {
+    it.only(`When the cursor is used, the reported messages are as expected, including the message sent in the request event`, async () => {
         const sender = await testEnv.getRandomClient()
         const receiver = await testEnv.getRandomClient()
 
@@ -291,7 +291,7 @@ describe('Integration - Conversation cursor', () => {
         expect(requestMesssageSender.length).to.be.equal(1)
     })
 
-    it(`When the cursor is moved, the reported messages are also moved along with the message sent in the request event`, async () => {
+    it.only(`When the cursor is moved, the reported messages are also moved along with the message sent in the request event`, async () => {
         const sender = await testEnv.getRandomClient()
         const receiver = await testEnv.getRandomClient()
 
@@ -330,7 +330,7 @@ describe('Integration - Conversation cursor', () => {
         const requestMesssageYes = secondPage.filter(msg => msg.text.includes(message))
 
         // Make sure we read all the expected messages
-        expect(secondPage.length).to.be.equal(2)
+        expect(secondPage.length).to.be.equal(3)
         expect(requestMesssageYes.length).to.be.equal(1)
     })
 


### PR DESCRIPTION
We are not correctly filtering out* events and this is a problem because we are sending empty messages from events like delete or with empty state keys as part of the message history.


*Filter out all org.decentraland.friendship events where:
- The body is empty OR
- The state key is empty OR
- The event is not a request