### PR TITLE
Filter friends in rooms from social service

### DIFF
--- a/etc/dcl-social-client.api.md
+++ b/etc/dcl-social-client.api.md
@@ -225,10 +225,10 @@ export class SocialClient implements SocialAPI {
         unreadMessages: boolean;
     }[];
     // (undocumented)
-    getAllCurrentFriendsConversations(): {
+    getAllCurrentFriendsConversations(): Promise<{
         conversation: Conversation;
         unreadMessages: boolean;
-    }[];
+    }[]>;
     // (undocumented)
     getAllFriendsAddresses(): Promise<string[]>;
     // (undocumented)

--- a/src/FriendsManagementAPI.ts
+++ b/src/FriendsManagementAPI.ts
@@ -4,7 +4,7 @@ import { SocialId, FriendshipRequest } from './types'
 export interface FriendsManagementAPI {
     getAllFriendsAddresses(): Promise<string[]>
     // @internal
-    getAllFriendsRooms(): Room[]
+    getAllRooms(): Room[]
     getPendingRequests(): FriendshipRequest[]
     isUserMyFriend(userId: SocialId): Promise<boolean>
     getMutualFriends(userId: SocialId): Promise<string[]>

--- a/src/FriendsManagementAPI.ts
+++ b/src/FriendsManagementAPI.ts
@@ -9,15 +9,25 @@ export interface FriendsManagementAPI {
     isUserMyFriend(userId: SocialId): Promise<boolean>
     getMutualFriends(userId: SocialId): Promise<string[]>
 
+    // @deprecated
     addAsFriend(userId: SocialId, message?: string | undefined): Promise<void>
+    // @deprecated
     deleteFriendshipWith(userId: SocialId): Promise<void>
+    // @deprecated
     approveFriendshipRequestFrom(userId: SocialId): Promise<void>
+    // @deprecated
     rejectFriendshipRequestFrom(userId: SocialId): Promise<void>
+    // @deprecated
     cancelFriendshipRequestTo(userId: SocialId): Promise<void>
 
+    // @deprecated
     onFriendshipRequest(listener: (requestedBy: SocialId, message?: string | undefined) => void): void
+    // @deprecated
     onFriendshipRequestCancellation(listener: (canceledBy: SocialId) => void): void
+    // @deprecated
     onFriendshipRequestRejection(listener: (rejectedBy: SocialId) => void): void
+    // @deprecated
     onFriendshipRequestApproval(listener: (approvedBy: SocialId) => void): void
+    // @deprecated
     onFriendshipDeletion(listener: (deletedBy: SocialId) => void): void
 }

--- a/src/FriendsManagementClient.ts
+++ b/src/FriendsManagementClient.ts
@@ -131,6 +131,7 @@ export class FriendsManagementClient implements FriendsManagementAPI {
         return await getMutualFriendsFromSocialService(baseUrl, userId, token)
     }
 
+    // @deprecated
     async addAsFriend(userId: SocialId, message?: string | undefined): Promise<void> {
         return this.actByStatus(
             userId,
@@ -146,6 +147,7 @@ export class FriendsManagementClient implements FriendsManagementAPI {
         )
     }
 
+    // @deprecated
     deleteFriendshipWith(userId: SocialId): Promise<void> {
         return this.actByStatus(
             userId,
@@ -154,6 +156,7 @@ export class FriendsManagementClient implements FriendsManagementAPI {
         )
     }
 
+    // @deprecated
     approveFriendshipRequestFrom(userId: SocialId): Promise<void> {
         return this.actByStatus(
             userId,
@@ -164,6 +167,7 @@ export class FriendsManagementClient implements FriendsManagementAPI {
         )
     }
 
+    // @deprecated
     rejectFriendshipRequestFrom(userId: SocialId): Promise<void> {
         return this.actByStatus(
             userId,
@@ -174,6 +178,7 @@ export class FriendsManagementClient implements FriendsManagementAPI {
         )
     }
 
+    // @deprecated
     cancelFriendshipRequestTo(userId: SocialId): Promise<void> {
         return this.actByStatus(
             userId,
@@ -184,22 +189,27 @@ export class FriendsManagementClient implements FriendsManagementAPI {
         )
     }
 
+    // @deprecated
     onFriendshipRequest(listener: (requestedBy: SocialId, message?: string | undefined) => void): void {
         return this.listenToEvent(FriendshipEvent.REQUEST, listener)
     }
 
+    // @deprecated
     onFriendshipRequestCancellation(listener: (canceledBy: SocialId) => void): void {
         return this.listenToEvent(FriendshipEvent.CANCEL, listener)
     }
 
+    // @deprecated
     onFriendshipRequestRejection(listener: (rejectedBy: SocialId) => void): void {
         return this.listenToEvent(FriendshipEvent.REJECT, listener)
     }
 
+    // @deprecated
     onFriendshipRequestApproval(listener: (approvedBy: SocialId) => void): void {
         return this.listenToEvent(FriendshipEvent.ACCEPT, listener)
     }
 
+    // @deprecated
     onFriendshipDeletion(listener: (deletedBy: SocialId) => void): void {
         return this.listenToEvent(FriendshipEvent.DELETE, listener)
     }

--- a/src/FriendsManagementClient.ts
+++ b/src/FriendsManagementClient.ts
@@ -75,11 +75,10 @@ export class FriendsManagementClient implements FriendsManagementAPI {
     }
 
     // @internal
-    getAllFriendsRooms(): Room[] {
+    getAllRooms(): Room[] {
         const rooms = this.matrixClient.getVisibleRooms()
         return rooms
             .filter(room => getConversationTypeFromRoom(this.matrixClient, room) === ConversationType.DIRECT)
-            .filter(room => this.getFriendshipStatusInRoom(room) === FriendshipStatus.FRIENDS)
     }
 
     getPendingRequests(): FriendshipRequest[] {

--- a/src/MessagingAPI.ts
+++ b/src/MessagingAPI.ts
@@ -31,7 +31,7 @@ export interface MessagingAPI {
      * Get all conversation with friends the user has joined
      * @returns `conversation` & `unreadMessages` boolean that indicates whether the conversation has unread messages.
      */
-    getAllCurrentFriendsConversations(): { conversation: Conversation; unreadMessages: boolean }[]
+    getAllCurrentFriendsConversations(): Promise<{ conversation: Conversation; unreadMessages: boolean }[]>
 
     /** Get total number of unseen messages from all conversations the user has joined */
     getTotalUnseenMessages(): number

--- a/src/SocialClient.ts
+++ b/src/SocialClient.ts
@@ -110,7 +110,7 @@ export class SocialClient implements SocialAPI {
         return socialClient
     }
 
-    //////    SESSION - STATUS MANAGEMENT    //////
+    ///    SESSION - STATUS MANAGEMENT    ///
 
     isLoggedIn(): boolean {
         return this.sessionManagement.isLoggedIn()
@@ -152,11 +152,12 @@ export class SocialClient implements SocialAPI {
         return this.sessionManagement.onStatusChange(listener)
     }
 
-    //////             MESSAGING             //////
+    ///             MESSAGING             ///
     getAllCurrentConversations(): { conversation: Conversation; unreadMessages: boolean }[] {
         return this.messaging.getAllCurrentConversations()
     }
-    getAllCurrentFriendsConversations(): { conversation: Conversation; unreadMessages: boolean }[] {
+
+    async getAllCurrentFriendsConversations(): Promise<{ conversation: Conversation; unreadMessages: boolean }[]> {
         return this.messaging.getAllCurrentFriendsConversations()
     }
 
@@ -237,8 +238,8 @@ export class SocialClient implements SocialAPI {
     }
 
     // @internal
-    getAllFriendsRooms(): Room[] {
-        return this.friendsManagement.getAllFriendsRooms()
+    getAllRooms(): Room[] {
+        return this.friendsManagement.getAllRooms()
     }
 
     getPendingRequests(): FriendshipRequest[] {


### PR DESCRIPTION
Chats with friends were not listed in the UI as the new flow was consulting for friendships in Matrix and now the source of truth for that is the Social Service

Tested in https://github.com/decentraland/unity-renderer/pull/5498